### PR TITLE
feat: Add display mode options to modal

### DIFF
--- a/src/modal-consumer.tsx
+++ b/src/modal-consumer.tsx
@@ -16,7 +16,7 @@ export const withModal =
     (props: P) => <ModalConsumer>{(context: IModalContext) => <Component modal={context} {...props} />}</ModalConsumer>;
 
 export const useModal = (): ModalHook => {
-    const {showModal, hideModal} = useContext(ModalContext);
+    const {showModal, hideModal, displayMode, setDisplayMode, containerRef} = useContext(ModalContext);
 
-    return {showModal, hideModal};
+    return {showModal, hideModal, displayMode, setDisplayMode, containerRef};
 };

--- a/src/modal-provider.tsx
+++ b/src/modal-provider.tsx
@@ -1,20 +1,38 @@
 import React, {ComponentType, PropsWithChildren, useCallback, useMemo, useState} from 'react';
 
 import ModalRenderer from './modal-renderer';
-import {ModalHook, ModalProps} from './quick-modal';
+import {DisplayMode, ModalHook, ModalProps} from './quick-modal';
 
 export type IModalContext = {
     component: ComponentType<ModalProps> | null;
     props: object;
     showModal: ModalHook['showModal'];
     hideModal: ModalHook['hideModal'];
+    displayMode: DisplayMode;
+    setDisplayMode: (mode: DisplayMode) => void;
+    containerRef?: React.RefObject<HTMLElement | null>;
 };
 
 export const ModalContext = React.createContext<IModalContext>({} as IModalContext);
 
-export const ModalProvider = ({children}: PropsWithChildren) => {
+const getInitialDisplayMode = (): DisplayMode => {
+    if (typeof window !== 'undefined') {
+        const storedMode = localStorage.getItem('modalDisplayMode');
+        if (storedMode === 'drawer' || storedMode === 'fullscreen') {
+            return storedMode;
+        }
+    }
+    return 'default';
+};
+
+type ModalProviderProps = PropsWithChildren<{
+    containerRef?: React.RefObject<HTMLElement | null>;
+}>;
+
+export const ModalProvider = ({children, containerRef}: ModalProviderProps) => {
     const [component, setComponent] = useState<ComponentType<ModalProps> | null>(null);
     const [props, setProps] = useState<object>({});
+    const [displayMode, setDisplayModeState] = useState<DisplayMode>(getInitialDisplayMode());
 
     const showModal: ModalHook['showModal'] = useCallback((component, props) => {
         setComponent(() => component as ComponentType<ModalProps>);
@@ -26,14 +44,24 @@ export const ModalProvider = ({children}: PropsWithChildren) => {
         setComponent(null);
     }, []);
 
+    const setDisplayMode = useCallback((mode: DisplayMode) => {
+        setDisplayModeState(mode);
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('modalDisplayMode', mode);
+        }
+    }, []);
+
     const context = useMemo(
         () => ({
             props,
             component,
             showModal,
             hideModal,
+            displayMode,
+            setDisplayMode,
+            containerRef,
         }),
-        [props, component, showModal, hideModal],
+        [props, component, showModal, hideModal, displayMode, setDisplayMode, containerRef],
     );
 
     return (

--- a/src/modal.css
+++ b/src/modal.css
@@ -1,0 +1,39 @@
+.modal-drawer .modal-dialog {
+    position: fixed;
+    top: 0;
+    right: 0;
+    margin: 0;
+    height: 100%;
+    transform: translateX(100%);
+    transition: transform 0.3s ease-out;
+}
+
+.modal-drawer.show .modal-dialog {
+    transform: translateX(0);
+}
+
+.modal-drawer .modal-content {
+    height: 100%;
+    border-radius: 0;
+}
+
+.modal-fullscreen.modal {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.modal-fullscreen .modal-dialog {
+    max-width: 100%;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+.modal-fullscreen .modal-content {
+    height: 100%;
+    border-radius: 0;
+    border: none;
+}

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -1,8 +1,9 @@
 import React, {PropsWithChildren, useCallback, useState} from 'react';
 
-import {Button, Modal as BootstrapModal} from 'react-bootstrap';
+import {Button, Dropdown, Modal as BootstrapModal} from 'react-bootstrap';
 
-import {useModal} from './quick-modal';
+import './modal.css';
+import {ModalProps, useModal} from './quick-modal';
 
 type buttonType =
     | 'primary'
@@ -29,15 +30,16 @@ type modalButton = {
     variant?: buttonType;
 };
 
-type props = PropsWithChildren<{
-    title: string;
-    cancelButton?: modalButton;
-    confirmButton?: modalButton;
-    size?: 'sm' | 'lg' | 'xl';
-    className?: string;
-    closeOnConfirm?: boolean;
-    keyboard?: boolean;
-}>;
+type props = ModalProps &
+    PropsWithChildren<{
+        title: string;
+        cancelButton?: modalButton;
+        confirmButton?: modalButton;
+        size?: 'sm' | 'lg' | 'xl';
+        className?: string;
+        closeOnConfirm?: boolean;
+        keyboard?: boolean;
+    }>;
 
 const Modal = ({
     cancelButton,
@@ -48,9 +50,10 @@ const Modal = ({
     title,
     children,
     closeOnConfirm = true,
+    hideModal,
 }: props) => {
     const [show, setShow] = useState(true);
-    const {hideModal} = useModal();
+    const {displayMode, setDisplayMode, containerRef} = useModal();
 
     const handleClose = useCallback(() => {
         hideModal();
@@ -77,15 +80,29 @@ const Modal = ({
 
     return (
         <BootstrapModal
-            className={className || ''}
+            className={`${className || ''} ${
+                displayMode === 'drawer' ? 'modal-drawer' : displayMode === 'fullscreen' ? 'modal-fullscreen' : ''
+            }`}
             show={show}
             onHide={handleClose}
             size={size}
+            container={displayMode === 'fullscreen' && containerRef ? containerRef.current : undefined}
             keyboard={keyboard}
             backdrop={keyboard === false ? 'static' : undefined}
         >
             <BootstrapModal.Header closeButton>
                 <BootstrapModal.Title>{title}</BootstrapModal.Title>
+                <Dropdown className="ms-auto">
+                    <Dropdown.Toggle variant="link" id="dropdown-basic">
+                        &#x22EE;
+                    </Dropdown.Toggle>
+
+                    <Dropdown.Menu>
+                        <Dropdown.Item onClick={() => setDisplayMode('default')}>Default</Dropdown.Item>
+                        <Dropdown.Item onClick={() => setDisplayMode('drawer')}>Drawer</Dropdown.Item>
+                        <Dropdown.Item onClick={() => setDisplayMode('fullscreen')}>Full Screen</Dropdown.Item>
+                    </Dropdown.Menu>
+                </Dropdown>
             </BootstrapModal.Header>
             <BootstrapModal.Body>{children}</BootstrapModal.Body>
             {cancelButton || confirmButton ? (

--- a/src/quick-modal.ts
+++ b/src/quick-modal.ts
@@ -8,9 +8,14 @@ export type ModalPropsWith = {
     modal: ModalHook;
 };
 
+export type DisplayMode = 'default' | 'drawer' | 'fullscreen';
+
 export type ModalHook = {
     showModal<P extends ModalProps>(component: ComponentType<P>, props?: Omit<P, keyof ModalProps>): void;
     hideModal(): void;
+    displayMode: DisplayMode;
+    setDisplayMode: (mode: DisplayMode) => void;
+    containerRef?: React.RefObject<HTMLElement | null>;
 };
 
 export type ModalProps = {


### PR DESCRIPTION
This commit introduces a new feature that allows you to change the display mode of the modal component.

A 3-dots menu has been added to the modal header, providing the following options:
- Default: The standard centered modal.
- Drawer: A sidebar that slides in from the right.
- Fullscreen: A mode that fills a specified container element.

Your selected display mode is persisted in `localStorage`.

The `ModalProvider` has been updated to accept a `containerRef` prop to support the fullscreen mode within a specific container.